### PR TITLE
Add missing call to mutateFormDataBeforeSave

### DIFF
--- a/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -25,6 +25,8 @@ trait Translatable
             $data[$attribute] = $this->record->getTranslation($attribute, $this->activeFormLocale);
         }
 
+        $data = $this->mutateFormDataBeforeSave($data);
+
         $this->form->fill($data);
 
         $this->callHook('afterFill');


### PR DESCRIPTION
In the trait `Translatable.php`, the base method `fillForm()` of the class `Resources/Pages/EditRecord` is being overwritten, but the redefined method is a missing call to the method `mutateFormDataBeforeSave()`. This causes own definitions of `mutateFormDataBeforeSave()` to not be called.