### PR TITLE
Add missing call to mutateFormDataBeforeFill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^8.0",
         "ext-intl": "*",
-        "filament/filament": "self.version",
+        "filament/filament": "^2.12",
         "illuminate/support": "^8.6|^9.0",
         "spatie/laravel-translatable": "^5.0|^6.0"
     },

--- a/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -25,6 +25,8 @@ trait Translatable
             $data[$attribute] = $this->record->getTranslation($attribute, $this->activeFormLocale);
         }
 
+        $data = $this->mutateFormDataBeforeFill($data);
+
         $this->form->fill($data);
 
         $this->callHook('afterFill');


### PR DESCRIPTION
In the trait Translatable.php, the base method fillForm() of the class Resources/Pages/EditRecord is being overwritten, but the redefined method is a missing call to the method mutateFormDataBeforeFill(). This causes own definitions of mutateFormDataBeforeFill() to not be called.